### PR TITLE
Support legacy LemonSqueezy env vars and fix fallback URL

### DIFF
--- a/api/lemonsqueezy/create-checkout.mjs
+++ b/api/lemonsqueezy/create-checkout.mjs
@@ -1,0 +1,258 @@
+import { config } from 'dotenv';
+
+// Load environment variables for local development. Vercel provides them automatically in production.
+config({ path: '.env.local', override: true });
+
+const LEMON_SQUEEZY_API_URL = 'https://api.lemonsqueezy.com/v1/checkouts';
+
+function getEnvValue(...keys) {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function parseBody(body) {
+  if (!body) return {};
+  if (typeof body === 'string') {
+    try {
+      return JSON.parse(body);
+    } catch (error) {
+      console.error('Unable to parse request body as JSON:', error);
+      return {};
+    }
+  }
+  return body;
+}
+
+function buildCustomFields(userId, customData) {
+  const customFields = {};
+
+  if (customData && typeof customData === 'object') {
+    for (const [key, value] of Object.entries(customData)) {
+      if (value !== undefined) {
+        customFields[key] = value;
+      }
+    }
+  }
+
+  if (userId) {
+    customFields.custom = userId;
+  }
+
+  return Object.keys(customFields).length > 0 ? customFields : undefined;
+}
+
+function createCheckoutPayload({
+  variantId,
+  storeId,
+  email,
+  name,
+  userId,
+  customData,
+  checkoutOptions,
+  productOptions,
+  returnUrl,
+  receiptLinkUrl,
+  receiptButtonText,
+  receiptThankYouNote,
+  testMode
+}) {
+  const checkoutData = {};
+
+  if (email) checkoutData.email = email;
+  if (name) checkoutData.name = name;
+
+  const customFields = buildCustomFields(userId, customData);
+  if (customFields) {
+    checkoutData.custom = customFields;
+  }
+
+  const defaultReturnUrl = returnUrl ?? receiptLinkUrl ?? null;
+
+  const payload = {
+    data: {
+      type: 'checkouts',
+      attributes: {
+        checkout_data: checkoutData,
+        checkout_options: {
+          embed: false,
+          media: false,
+          logo: false,
+          ...(checkoutOptions && typeof checkoutOptions === 'object' ? checkoutOptions : {})
+        },
+        product_options: {
+          ...(productOptions && typeof productOptions === 'object' ? productOptions : {}),
+          redirect_url: productOptions?.redirect_url ?? defaultReturnUrl ?? undefined,
+          receipt_link_url: productOptions?.receipt_link_url ?? defaultReturnUrl ?? undefined,
+          receipt_button_text: receiptButtonText ?? productOptions?.receipt_button_text ?? 'Return to App',
+          receipt_thank_you_note: receiptThankYouNote ?? productOptions?.receipt_thank_you_note ?? 'Thank you for your purchase!'
+        },
+        test_mode: testMode
+      },
+      relationships: {
+        store: {
+          data: {
+            type: 'stores',
+            id: storeId
+          }
+        },
+        variant: {
+          data: {
+            type: 'variants',
+            id: variantId
+          }
+        }
+      }
+    }
+  };
+
+  // Lemon Squeezy requires the enabled_variants when using product_options
+  if (!payload.data.attributes.product_options.enabled_variants) {
+    payload.data.attributes.product_options.enabled_variants = [variantId];
+  }
+
+  // Clean up any undefined values inside checkout_data
+  if (Object.keys(payload.data.attributes.checkout_data).length === 0) {
+    delete payload.data.attributes.checkout_data;
+  }
+
+  // Remove undefined product option fields to avoid API validation errors
+  payload.data.attributes.product_options = Object.fromEntries(
+    Object.entries(payload.data.attributes.product_options).filter(([, value]) => value !== undefined && value !== null)
+  );
+
+  return payload;
+}
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(200);
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+    return;
+  }
+
+  const body = parseBody(req.body);
+  const {
+    variantId,
+    email,
+    userId,
+    name,
+    customData,
+    checkoutOptions,
+    productOptions,
+    returnUrl,
+    receiptLinkUrl,
+    receiptButtonText,
+    receiptThankYouNote,
+    testMode
+  } = body;
+
+  if (!variantId) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'variantId is required' }));
+    return;
+  }
+
+  const apiKey = getEnvValue(
+    'LEMONSQUEEZY_API_KEY',
+    'VITE_LEMONSQUEEZY_API_KEY',
+    'LEMON_SQUEEZY_API_KEY',
+    'VITE_LEMON_SQUEEZY_API_KEY'
+  );
+  const storeId = getEnvValue(
+    'LEMONSQUEEZY_STORE_ID',
+    'VITE_LEMONSQUEEZY_STORE_ID',
+    'LEMON_SQUEEZY_STORE_ID',
+    'VITE_LEMON_SQUEEZY_STORE_ID'
+  );
+
+  if (!apiKey || !storeId) {
+    console.error('Missing Lemon Squeezy credentials. Ensure LEMONSQUEEZY_API_KEY and LEMONSQUEEZY_STORE_ID (or legacy VITE_ variants) are set.');
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Lemon Squeezy is not configured on the server' }));
+    return;
+  }
+
+  const vercelEnv = process.env.VERCEL_ENV;
+  const nodeEnv = process.env.NODE_ENV;
+  const envTestMode = process.env.LEMONSQUEEZY_TEST_MODE === 'true';
+  const resolvedTestMode = typeof testMode === 'boolean'
+    ? testMode
+    : (typeof vercelEnv === 'string'
+      ? vercelEnv !== 'production'
+      : nodeEnv !== 'production') || envTestMode;
+
+  const payload = createCheckoutPayload({
+    variantId,
+    storeId,
+    email,
+    name,
+    userId,
+    customData,
+    checkoutOptions,
+    productOptions,
+    returnUrl,
+    receiptLinkUrl,
+    receiptButtonText,
+    receiptThankYouNote,
+    testMode: resolvedTestMode
+  });
+
+  try {
+    const response = await fetch(LEMON_SQUEEZY_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        Accept: 'application/vnd.api+json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const result = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      console.error('Lemon Squeezy checkout creation failed:', result);
+      res.writeHead(response.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        error: result?.errors?.[0]?.detail || 'Failed to create Lemon Squeezy checkout',
+        details: result
+      }));
+      return;
+    }
+
+    const checkoutUrl = result?.data?.attributes?.url;
+
+    if (!checkoutUrl) {
+      console.error('No checkout URL returned from Lemon Squeezy:', result);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'No checkout URL returned from Lemon Squeezy', details: result }));
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      url: checkoutUrl,
+      checkoutId: result?.data?.id,
+      testMode: resolvedTestMode
+    }));
+  } catch (error) {
+    console.error('Error creating Lemon Squeezy checkout:', error);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Unexpected error creating checkout' }));
+  }
+}

--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },
+      '/api/lemonsqueezy': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/lemonsqueezy/, '/lemonsqueezy'),
+      },
     },
   },
   optimizeDeps: {

--- a/docs/LEMONSQUEEZY_SETUP.md
+++ b/docs/LEMONSQUEEZY_SETUP.md
@@ -43,6 +43,12 @@ Create a `.env.local` file in your project root with the following variables:
 LEMONSQUEEZY_API_KEY=your_api_key_here
 LEMONSQUEEZY_STORE_ID=your_store_id_here
 
+# Client-side configuration used by the checkout buttons
+VITE_LEMONSQUEEZY_VARIANT_ID=your_variant_id_here
+
+# Optional: override the fallback checkout URL used if the API fails
+# VITE_LEMONSQUEEZY_FALLBACK_URL=https://your-store.lemonsqueezy.com/buy/your_shareable_checkout
+
 # Optional: force test mode outside of production
 # LEMONSQUEEZY_TEST_MODE=true
 
@@ -53,17 +59,16 @@ OPENAI_API_KEY=your_openai_api_key_here
 > ℹ️ The Vite client no longer talks directly to LemonSqueezy. The API key and
 > store ID are only required on the serverless function (Vercel or the local
 > development server started with `npm run dev:api`), so they remain private.
+> The client only needs the public variant ID (and optionally the shareable
+> fallback checkout URL) which are safe to expose via `VITE_` variables.
 
-### 4. Update Variant ID
+### 4. Configure Variant and Fallback URLs
 
-In `src/components/Header.tsx`, replace the hardcoded variant ID with your actual variant ID:
-
-```typescript
-// Replace this line in both checkout buttons:
-variantId: '6ea39e2c-da56-46cf-a1f5-d2df1bd30f9f',
-// With your actual variant ID:
-variantId: 'your_actual_variant_id_here',
-```
+Set `VITE_LEMONSQUEEZY_VARIANT_ID` to the variant you want to sell. If you have
+an existing hosted checkout you prefer to fall back to when the API is
+unavailable, set `VITE_LEMONSQUEEZY_FALLBACK_URL` to that shareable URL. The
+buttons in the app will automatically pick up these values—no code edits are
+required.
 
 ## 🚀 How It Works
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,12 @@ import { CurrencyDropdown } from './CurrencyDropdown';
 import { trackInvestmentActions } from './GoogleAnalytics';
 import { useAuth } from '../contexts/AuthContext';
 import { useSubscription } from '../contexts/SubscriptionContext';
-import { openLemonSqueezyCheckout, openLemonSqueezyCheckoutLegacy } from '../lib/openCheckout';
+import {
+  LEMON_SQUEEZY_FALLBACK_URL,
+  LEMON_SQUEEZY_VARIANT_ID,
+  openLemonSqueezyCheckout,
+  openLemonSqueezyCheckoutLegacy
+} from '../lib/openCheckout';
 
 interface HeaderProps {
   onAddInvestment: () => void;
@@ -126,7 +131,7 @@ export function Header({
                     if (user) {
                       try {
                         await openLemonSqueezyCheckout({
-                          variantId: '1000932',
+                          variantId: LEMON_SQUEEZY_VARIANT_ID,
                           email: user.email || undefined,
                           userId: user.id,
                           name: user.user_metadata?.full_name || undefined
@@ -135,7 +140,7 @@ export function Header({
                         console.error('Checkout error:', error);
                         // Fallback to legacy method
                         openLemonSqueezyCheckoutLegacy(
-                          'https://portfolio-tracker.lemonsqueezy.com/buy/1000932',
+                          LEMON_SQUEEZY_FALLBACK_URL,
                           user.email || undefined,
                           user.id
                         );
@@ -177,7 +182,7 @@ export function Header({
                     if (user) {
                       try {
                         await openLemonSqueezyCheckout({
-                          variantId: '1000932',
+                          variantId: LEMON_SQUEEZY_VARIANT_ID,
                           email: user.email || undefined,
                           userId: user.id,
                           name: user.user_metadata?.full_name || undefined
@@ -186,7 +191,7 @@ export function Header({
                         console.error('Checkout error:', error);
                         // Fallback to legacy method
                         openLemonSqueezyCheckoutLegacy(
-                          'https://portfolio-tracker.lemonsqueezy.com/buy/1000932',
+                          LEMON_SQUEEZY_FALLBACK_URL,
                           user.email || undefined,
                           user.id
                         );

--- a/src/lib/openCheckout.ts
+++ b/src/lib/openCheckout.ts
@@ -3,94 +3,112 @@ interface LemonSqueezyCheckoutOptions {
   email?: string;
   userId?: string;
   name?: string;
-  customData?: Record<string, any>;
+  customData?: Record<string, unknown>;
+  checkoutOptions?: Record<string, unknown>;
+  productOptions?: Record<string, unknown>;
+  returnUrl?: string;
+  receiptLinkUrl?: string;
+  receiptButtonText?: string;
+  receiptThankYouNote?: string;
+  testMode?: boolean;
+}
+
+interface LemonSqueezyCheckoutResponse {
+  url: string;
+  checkoutId?: string;
+  testMode?: boolean;
+}
+
+const CHECKOUT_ENDPOINT = '/api/lemonsqueezy/create-checkout';
+
+function buildCheckoutRequestPayload(options: LemonSqueezyCheckoutOptions) {
+  const {
+    variantId,
+    email,
+    userId,
+    name,
+    customData,
+    checkoutOptions,
+    productOptions,
+    returnUrl,
+    receiptLinkUrl,
+    receiptButtonText,
+    receiptThankYouNote,
+    testMode
+  } = options;
+
+  const baseReturnUrl = returnUrl ?? `${window.location.origin}/`;
+  const payload: Record<string, unknown> = {
+    variantId,
+    email,
+    userId,
+    name,
+    customData,
+    checkoutOptions,
+    productOptions,
+    returnUrl: baseReturnUrl,
+    receiptLinkUrl: receiptLinkUrl ?? baseReturnUrl,
+    receiptButtonText,
+    receiptThankYouNote
+  };
+
+  if (typeof testMode === 'boolean') {
+    payload.testMode = testMode;
+  } else if (import.meta.env.DEV) {
+    payload.testMode = true;
+  }
+
+  return Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => {
+      if (value === undefined || value === null) {
+        return false;
+      }
+      if (typeof value === 'object' && !Array.isArray(value)) {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+      }
+      return true;
+    })
+  );
 }
 
 export async function openLemonSqueezyCheckout(options: LemonSqueezyCheckoutOptions) {
-  const { variantId, email, userId, name, customData } = options;
-  
-  try {
-    // Create checkout using LemonSqueezy API
-    const checkoutData = {
-      data: {
-        type: 'checkouts',
-        attributes: {
-          checkout_data: {
-            email: email || undefined,
-            name: name || undefined,
-            custom: userId ? [userId] : undefined,
-            ...customData
-          },
-          product_options: {
-            enabled_variants: [variantId],
-            redirect_url: `${window.location.origin}/`,
-            receipt_link_url: `${window.location.origin}/`,
-            receipt_button_text: 'Return to App',
-            receipt_thank_you_note: 'Thank you for your purchase!'
-          },
-          checkout_options: {
-            embed: false,
-            media: false,
-            logo: false
-          },
-          preview: false,
-          test_mode: import.meta.env.DEV
-        },
-        relationships: {
-          store: {
-            data: {
-              type: 'stores',
-              id: import.meta.env.VITE_LEMONSQUEEZY_STORE_ID
-            }
-          },
-          variant: {
-            data: {
-              type: 'variants',
-              id: variantId
-            }
-          }
-        }
-      }
-    };
+  const payload = buildCheckoutRequestPayload(options);
 
-    const response = await fetch('https://api.lemonsqueezy.com/v1/checkouts', {
+  let response: Response;
+  let result: Partial<LemonSqueezyCheckoutResponse> & { error?: string } | null = null;
+
+  try {
+    response = await fetch(CHECKOUT_ENDPOINT, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/vnd.api+json',
-        'Accept': 'application/vnd.api+json',
-        'Authorization': `Bearer ${import.meta.env.VITE_LEMONSQUEEZY_API_KEY}`
+        'Content-Type': 'application/json'
       },
-      body: JSON.stringify(checkoutData)
+      body: JSON.stringify(payload)
     });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      console.error('LemonSqueezy checkout creation failed:', errorData);
-      throw new Error(`Checkout creation failed: ${response.status} ${response.statusText}`);
+    try {
+      result = await response.json();
+    } catch (parseError) {
+      console.error('Failed to parse Lemon Squeezy API response:', parseError);
+      result = null;
     }
 
-    const result = await response.json();
-    const checkoutUrl = result.data.attributes.url;
-    
-    if (checkoutUrl) {
-      window.open(checkoutUrl, '_blank', 'noopener');
-    } else {
+    if (!response.ok) {
+      const errorMessage = result?.error || `Checkout creation failed: ${response.status} ${response.statusText}`;
+      throw new Error(errorMessage);
+    }
+
+    const checkoutUrl = result?.url;
+
+    if (!checkoutUrl) {
       throw new Error('No checkout URL returned from LemonSqueezy');
     }
+
+    window.open(checkoutUrl, '_blank', 'noopener');
+    return result as LemonSqueezyCheckoutResponse;
   } catch (error) {
     console.error('Error creating LemonSqueezy checkout:', error);
-    
-    // Fallback to direct URL approach for development
-    if (import.meta.env.DEV) {
-      const fallbackUrl = `https://portfolio-tracker.lemonsqueezy.com/buy/${variantId}`;
-      const url = new URL(fallbackUrl);
-      if (email) url.searchParams.set('checkout[email]', email);
-      if (userId) url.searchParams.set('checkout[custom]', userId);
-      window.open(url.toString(), '_blank', 'noopener');
-    } else {
-      // In production, show user-friendly error
-      alert('Unable to open checkout. Please try again or contact support.');
-    }
+    throw error;
   }
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,9 @@
     "api/coingecko.js": {
       "maxDuration": 30
     },
+    "api/lemonsqueezy/create-checkout.mjs": {
+      "maxDuration": 30
+    },
     "api/yahoo.js": {
       "maxDuration": 30
     }


### PR DESCRIPTION
## Summary
- read LemonSqueezy API credentials from both the new server-side variables and the legacy VITE_ names so existing deployments keep working
- default the generated custom field to the legacy `checkout[custom]` slug so webhook data matches prior expectations
- restore the legacy checkout fallback URL shape for cases where the API call still fails

## Testing
- npm run lint *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f0b0989c832c931dfbfd2201aa43